### PR TITLE
use a locally installed typescript compiler (tsx) from devDependencies instead of only working with globally available tsx

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -2,7 +2,8 @@
 
 import {runCliScript} from '@augment-vir/node';
 import {join} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-const cliPath = join(import.meta.dirname, 'src', 'generator', 'cli.script.ts');
+const cliPath = join(fileURLToPath(import.meta.dirname), 'src', 'generator', 'cli.script.ts');
 
-await runCliScript(cliPath, import.meta.filename, 'prisma-map');
+await runCliScript(cliPath, fileURLToPath(import.meta.filename), 'prisma-map');

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
                 "prettier-plugin-sort-json": "^4.1.1",
                 "prettier-plugin-toml": "^2.0.1",
                 "prisma": "^6.2.1",
+                "tsx": "^4.19.2",
                 "typedoc": "^0.27.6",
                 "typescript": "^5.7.3",
                 "typescript-eslint": "^8.21.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "prettier-plugin-sort-json": "^4.1.1",
         "prettier-plugin-toml": "^2.0.1",
         "prisma": "^6.2.1",
+        "tsx": "^4.19.2",
         "typedoc": "^0.27.6",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.21.0",


### PR DESCRIPTION
This PR updates the project to utilize a locally installed TypeScript compiler (tsx) from devDependencies, rather than relying solely on a globally available tsx installation.